### PR TITLE
chore: add devEngines.packageManager to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "author": "DWANGO Co., Ltd.",
   "scripts": {
     "build": "rimraf ./script && tsc && akashic-cli-scan asset script",
-	"update": "akashic-cli-scan asset && akashic-cli-scan globalScripts",
-	"start": "akashic-sandbox .",
-	"lint": "eslint src/**/*.ts --fix"
+    "update": "akashic-cli-scan asset && akashic-cli-scan globalScripts",
+    "start": "akashic-sandbox .",
+    "lint": "eslint src/**/*.ts --fix"
   },
   "dependencies": {
     "@akashic-extension/akashic-box2d": "~3.1.0"
@@ -25,5 +25,12 @@
     "eslint-plugin-jest": "^26.5.3",
     "rimraf": "3.0.2",
     "typescript": "4.7.4"
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "npm",
+      "version": ">=11.11.0",
+      "onFail": "error"
+    }
   }
 }


### PR DESCRIPTION
This PR adds `devEngines.packageManager` to package.json to enforce npm version.